### PR TITLE
Disable know-false positive URL

### DIFF
--- a/.tekton/rhobs-token-refresher-main-pull-request.yaml
+++ b/.tekton/rhobs-token-refresher-main-pull-request.yaml
@@ -376,6 +376,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: ARGS
         value: "--project-name=rhobs-konflux-token-refresher --report --org=824715e7-b597-4123-bdb7-ba8abc3d3b2f"
+      - name: KFP_GIT_URL
+        value: ""
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/rhobs-token-refresher-main-push.yaml
+++ b/.tekton/rhobs-token-refresher-main-push.yaml
@@ -363,6 +363,8 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: ARGS
         value: "--project-name=rhobs-konflux-token-refresher --report --org=824715e7-b597-4123-bdb7-ba8abc3d3b2f"
+      - name: KFP_GIT_URL
+        value: ""
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
The default URL isn't accessible from the Konflux cluster.